### PR TITLE
Add <cstdint> headers

### DIFF
--- a/Flye/src/assemble/chimera.cpp
+++ b/Flye/src/assemble/chimera.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include <vector>
 #include <iostream>
 #include <unordered_set>

--- a/Flye/src/assemble/extender.cpp
+++ b/Flye/src/assemble/extender.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include <limits>
 #include <algorithm>
 #include <iomanip>

--- a/Flye/src/assemble/parameters_estimator.cpp
+++ b/Flye/src/assemble/parameters_estimator.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include "parameters_estimator.h"
 #include "../common/logger.h"
 

--- a/Flye/src/bin/assemble.cpp
+++ b/Flye/src/bin/assemble.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include <iostream>
 #include <signal.h>
 #include <stdlib.h>

--- a/Flye/src/bin/contigger.cpp
+++ b/Flye/src/bin/contigger.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include <iostream>
 #include <signal.h>
 #include <stdlib.h>

--- a/Flye/src/bin/polisher.cpp
+++ b/Flye/src/bin/polisher.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include <ctime>
 #include <iostream>
 #include <getopt.h>

--- a/Flye/src/bin/repeat.cpp
+++ b/Flye/src/bin/repeat.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include <iostream>
 #include <signal.h>
 #include <stdlib.h>

--- a/Flye/src/contigger/contig_extender.cpp
+++ b/Flye/src/contigger/contig_extender.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include "contig_extender.h"
 #include "../repeat_graph/output_generator.h"
 #include <cmath>

--- a/Flye/src/polishing/alignment.cpp
+++ b/Flye/src/polishing/alignment.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include "alignment.h"
 #include <chrono>
 

--- a/Flye/src/polishing/bubble_processor.cpp
+++ b/Flye/src/polishing/bubble_processor.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include <chrono>
 #include <thread>
 #include <sys/stat.h>

--- a/Flye/src/polishing/dinucleotide_fixer.cpp
+++ b/Flye/src/polishing/dinucleotide_fixer.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 //
+#include <cstdint>
 #include "dinucleotide_fixer.h"
 #include "alignment.h"
 

--- a/Flye/src/polishing/general_polisher.cpp
+++ b/Flye/src/polishing/general_polisher.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include "general_polisher.h"
 #include "alignment.h"
 

--- a/Flye/src/polishing/homo_polisher.cpp
+++ b/Flye/src/polishing/homo_polisher.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include <algorithm>
 #include <unordered_set>
 

--- a/Flye/src/polishing/subs_matrix.cpp
+++ b/Flye/src/polishing/subs_matrix.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include <sstream>
 #include <vector>
 #include <cmath>

--- a/Flye/src/repeat_graph/graph_processing.cpp
+++ b/Flye/src/repeat_graph/graph_processing.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include <deque>
 
 #include "graph_processing.h"

--- a/Flye/src/repeat_graph/multiplicity_inferer.cpp
+++ b/Flye/src/repeat_graph/multiplicity_inferer.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include "multiplicity_inferer.h"
 #include "graph_processing.h"
 #include "../common/disjoint_set.h"

--- a/Flye/src/repeat_graph/output_generator.cpp
+++ b/Flye/src/repeat_graph/output_generator.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include "output_generator.h"
 #include "../sequence/consensus_generator.h"
 #include <iomanip>

--- a/Flye/src/repeat_graph/read_aligner.cpp
+++ b/Flye/src/repeat_graph/read_aligner.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include "read_aligner.h"
 #include "../common/parallel.h"
 #include <cmath>

--- a/Flye/src/repeat_graph/repeat_graph.cpp
+++ b/Flye/src/repeat_graph/repeat_graph.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include <deque>
 #include <iomanip>
 #include <cmath>

--- a/Flye/src/repeat_graph/repeat_resolver.cpp
+++ b/Flye/src/repeat_graph/repeat_resolver.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include <cmath>
 
 

--- a/Flye/src/sequence/consensus_generator.cpp
+++ b/Flye/src/sequence/consensus_generator.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include <cassert>
 #include <algorithm>
 #include <fstream>

--- a/Flye/src/sequence/overlap.cpp
+++ b/Flye/src/sequence/overlap.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include <set>
 #include <iostream>
 #include <cassert>

--- a/Flye/src/sequence/sequence.cpp
+++ b/Flye/src/sequence/sequence.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include "sequence.h"
 
 std::vector<size_t> DnaSequence::_dnaTable;

--- a/Flye/src/sequence/sequence_container.cpp
+++ b/Flye/src/sequence/sequence_container.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include <stdexcept>
 #include <fstream>
 #include <sstream>

--- a/Flye/src/sequence/vertex_index.cpp
+++ b/Flye/src/sequence/vertex_index.cpp
@@ -2,6 +2,7 @@
 //This file is a part of ABruijn program.
 //Released under the BSD license (see LICENSE file)
 
+#include <cstdint>
 #include <stdexcept>
 #include <iostream>
 #include <unordered_set>


### PR DESCRIPTION
## Summary
- include `<cstdint>` in all Flye src `.cpp` files to ensure fixed-width integer types

## Testing
- `grep -n '<cstdint>' -R Flye/src | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_686dd73b48a083278fe2b764cf563b4f